### PR TITLE
Format code, update feature name, and some cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,6 @@ jobs:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@nightly
     - name: Build docs
-      continue-on-error: ${{ github.ref != env.default-branch && github.event_name != 'pull_request' }}
       run: |
         for crate in axdriver_base axdriver_block axdriver_net axdriver_display axdriver_pci axdriver_virtio;
         do

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
 
 [workspace.package]
 version = "0.1.2"
+edition = "2021"
 authors = ["Yuekai Jia <equation618@gmail.com>"]
 license = "GPL-3.0-or-later OR Apache-2.0 OR MulanPSL-2.0"
 homepage = "https://github.com/arceos-org/arceos"
@@ -22,7 +23,8 @@ categories = ["os", "no-std", "hardware-support"]
 [workspace.dependencies]
 axdriver_base = { path = "axdriver_base", version = "0.1" }
 axdriver_block = { path = "axdriver_block", version = "0.1" }
-axdriver_net = { path = "axdriver_net", version = "0.1" }
 axdriver_display = { path = "axdriver_display", version = "0.1" }
+axdriver_net = { path = "axdriver_net", version = "0.1" }
 axdriver_pci = { path = "axdriver_pci", version = "0.1" }
 axdriver_virtio = { path = "axdriver_virtio", version = "0.1" }
+log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 
 [workspace.package]
 version = "0.1.2"
-edition = "2021"
+edition = "2024"
 authors = ["Yuekai Jia <equation618@gmail.com>"]
 license = "GPL-3.0-or-later OR Apache-2.0 OR MulanPSL-2.0"
 homepage = "https://github.com/arceos-org/arceos"

--- a/axdriver_base/Cargo.toml
+++ b/axdriver_base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axdriver_base"
-edition = "2021"
+edition.workspace = true
 description = "Common interfaces for all kinds of device drivers"
 documentation = "https://arceos-org.github.io/axdriver_crates/axdriver_base"
 keywords = ["arceos", "driver"]

--- a/axdriver_base/src/lib.rs
+++ b/axdriver_base/src/lib.rs
@@ -5,7 +5,8 @@
 //! device types:
 //!
 //! - [`axdriver_block`][2]: Common traits for block storage drivers.
-//! - [`axdriver_display`][3]: Common traits and types for graphics display drivers.
+//! - [`axdriver_display`][3]: Common traits and types for graphics display
+//!   drivers.
 //! - [`axdriver_net`][4]: Common traits and types for network (NIC) drivers.
 //!
 //! [1]: https://github.com/arceos-org/arceos

--- a/axdriver_block/Cargo.toml
+++ b/axdriver_block/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axdriver_block"
-edition = "2021"
+edition.workspace = true
 description = "Common traits and types for block storage drivers"
 documentation = "https://arceos-org.github.io/axdriver_crates/axdriver_block"
 keywords = ["arceos", "driver", "blk"]
@@ -17,6 +17,6 @@ bcm2835-sdhci = ["dep:bcm2835-sdhci"]
 default = []
 
 [dependencies]
-log = "0.4"
 axdriver_base = { workspace = true }
 bcm2835-sdhci = { git = "https://github.com/lhw2002426/bcm2835-sdhci.git", rev = "e974f16", optional = true }
+log = { workspace = true }

--- a/axdriver_block/src/bcm2835sdhci.rs
+++ b/axdriver_block/src/bcm2835sdhci.rs
@@ -1,10 +1,10 @@
 //! SD card driver for raspi4
 
-extern crate alloc;
-use crate::BlockDriverOps;
 use axdriver_base::{BaseDriverOps, DevError, DevResult, DeviceType};
 use bcm2835_sdhci::Bcm2835SDhci::{EmmcCtl, BLOCK_SIZE};
 use bcm2835_sdhci::SDHCIError;
+
+use crate::BlockDriverOps;
 
 /// BCM2835 SDHCI driver (Raspberry Pi SD card).
 pub struct SDHCIDriver(EmmcCtl);

--- a/axdriver_block/src/bcm2835sdhci.rs
+++ b/axdriver_block/src/bcm2835sdhci.rs
@@ -1,8 +1,10 @@
 //! SD card driver for raspi4
 
 use axdriver_base::{BaseDriverOps, DevError, DevResult, DeviceType};
-use bcm2835_sdhci::Bcm2835SDhci::{EmmcCtl, BLOCK_SIZE};
-use bcm2835_sdhci::SDHCIError;
+use bcm2835_sdhci::{
+    Bcm2835SDhci::{BLOCK_SIZE, EmmcCtl},
+    SDHCIError,
+};
 
 use crate::BlockDriverOps;
 

--- a/axdriver_block/src/lib.rs
+++ b/axdriver_block/src/lib.rs
@@ -1,7 +1,7 @@
 //! Common traits and types for block storage device drivers (i.e. disk).
 
 #![no_std]
-#![cfg_attr(doc, feature(doc_auto_cfg))]
+#![cfg_attr(doc, feature(doc_cfg))]
 
 #[cfg(feature = "ramdisk")]
 pub mod ramdisk;

--- a/axdriver_block/src/ramdisk.rs
+++ b/axdriver_block/src/ramdisk.rs
@@ -2,9 +2,10 @@
 
 extern crate alloc;
 
-use crate::BlockDriverOps;
 use alloc::{vec, vec::Vec};
 use axdriver_base::{BaseDriverOps, DevError, DevResult, DeviceType};
+
+use crate::BlockDriverOps;
 
 const BLOCK_SIZE: usize = 512;
 

--- a/axdriver_block/src/ramdisk.rs
+++ b/axdriver_block/src/ramdisk.rs
@@ -3,6 +3,7 @@
 extern crate alloc;
 
 use alloc::{vec, vec::Vec};
+
 use axdriver_base::{BaseDriverOps, DevError, DevResult, DeviceType};
 
 use crate::BlockDriverOps;

--- a/axdriver_display/Cargo.toml
+++ b/axdriver_display/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axdriver_display"
-edition = "2021"
+edition.workspace = true
 description = "Common traits and types for graphics device drivers"
 documentation = "https://arceos-org.github.io/axdriver_crates/axdriver_display"
 keywords = ["arceos", "driver", "gpu", "framebuffer"]

--- a/axdriver_display/src/lib.rs
+++ b/axdriver_display/src/lib.rs
@@ -33,7 +33,7 @@ impl<'a> FrameBuffer<'a> {
     /// Caller must insure that the given memory region is valid and accessible.
     pub unsafe fn from_raw_parts_mut(ptr: *mut u8, len: usize) -> Self {
         Self {
-            _raw: core::slice::from_raw_parts_mut(ptr, len),
+            _raw: unsafe { core::slice::from_raw_parts_mut(ptr, len) },
         }
     }
 

--- a/axdriver_display/src/lib.rs
+++ b/axdriver_display/src/lib.rs
@@ -30,7 +30,7 @@ impl<'a> FrameBuffer<'a> {
     ///
     /// # Safety
     ///
-    /// Caller must insure that the given memory region is valid and accessible.
+    /// Caller must ensure that the given memory region is valid and accessible.
     pub unsafe fn from_raw_parts_mut(ptr: *mut u8, len: usize) -> Self {
         Self {
             _raw: unsafe { core::slice::from_raw_parts_mut(ptr, len) },

--- a/axdriver_net/Cargo.toml
+++ b/axdriver_net/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "axdriver_net"
-edition = "2021"
-authors = ["Yuekai Jia <equation618@gmail.com>", "ChengXiang Qi <kuangjux@outlook.com>"]
+edition.workspace = true
+authors = [
+    "Yuekai Jia <equation618@gmail.com>",
+    "ChengXiang Qi <kuangjux@outlook.com>",
+]
 description = "Common traits and types for network device (NIC) drivers"
 documentation = "https://arceos-org.github.io/axdriver_crates/axdriver_net"
 keywords = ["arceos", "driver", "nic"]
@@ -17,8 +20,8 @@ ixgbe = ["dep:ixgbe-driver"]
 fxmac = ["dep:fxmac_rs"]
 
 [dependencies]
-spin = "0.9"
-log = "0.4"
 axdriver_base = { workspace = true }
-ixgbe-driver = { git = "https://github.com/KuangjuX/ixgbe-driver.git", rev = "8e5eb74", optional = true}
 fxmac_rs = { git = "https://github.com/elliott10/fxmac_rs.git", rev = "0dbc3916", optional = true }
+ixgbe-driver = { git = "https://github.com/KuangjuX/ixgbe-driver.git", rev = "8e5eb74", optional = true }
+log = { workspace = true }
+spin = "0.9"

--- a/axdriver_net/src/fxmac.rs
+++ b/axdriver_net/src/fxmac.rs
@@ -3,7 +3,7 @@ use core::ptr::NonNull;
 
 use axdriver_base::{BaseDriverOps, DevError, DevResult, DeviceType};
 pub use fxmac_rs::KernelFunc;
-use fxmac_rs::{self, xmac_init, FXmac, FXmacGetMacAddress, FXmacLwipPortTx, FXmacRecvHandler};
+use fxmac_rs::{self, FXmac, FXmacGetMacAddress, FXmacLwipPortTx, FXmacRecvHandler, xmac_init};
 use log::*;
 
 use crate::{EthernetAddress, NetBufPtr, NetDriverOps};

--- a/axdriver_net/src/ixgbe.rs
+++ b/axdriver_net/src/ixgbe.rs
@@ -2,8 +2,8 @@ use alloc::{collections::VecDeque, sync::Arc};
 use core::{convert::From, mem::ManuallyDrop, ptr::NonNull};
 
 use axdriver_base::{BaseDriverOps, DevError, DevResult, DeviceType};
+pub use ixgbe_driver::{INTEL_82599, INTEL_VEND, IxgbeHal, PhysAddr};
 use ixgbe_driver::{IxgbeDevice, IxgbeError, IxgbeNetBuf, MemPool, NicDevice};
-pub use ixgbe_driver::{IxgbeHal, PhysAddr, INTEL_82599, INTEL_VEND};
 use log::*;
 
 use crate::{EthernetAddress, NetBufPtr, NetDriverOps};
@@ -142,8 +142,8 @@ impl From<IxgbeNetBuf> for NetBufPtr {
     fn from(buf: IxgbeNetBuf) -> Self {
         // Use `ManuallyDrop` to avoid drop `tx_buf`.
         let mut buf = ManuallyDrop::new(buf);
-        // In ixgbe, `raw_ptr` is the pool entry, `buf_ptr` is the packet ptr, `len` is packet len
-        // to avoid too many dynamic memory allocation.
+        // In ixgbe, `raw_ptr` is the pool entry, `buf_ptr` is the packet ptr, `len` is
+        // packet len to avoid too many dynamic memory allocation.
         let buf_ptr = buf.packet_mut().as_mut_ptr();
         Self::new(
             NonNull::new(buf.pool_entry() as *mut u8).unwrap(),

--- a/axdriver_net/src/lib.rs
+++ b/axdriver_net/src/lib.rs
@@ -1,7 +1,7 @@
 //! Common traits and types for network device (NIC) drivers.
 
 #![no_std]
-#![cfg_attr(doc, feature(doc_auto_cfg))]
+#![cfg_attr(doc, feature(doc_cfg))]
 
 #[cfg(feature = "fxmac")]
 /// fxmac driver for PhytiumPi

--- a/axdriver_net/src/lib.rs
+++ b/axdriver_net/src/lib.rs
@@ -44,8 +44,8 @@ pub trait NetDriverOps: BaseDriverOps {
     /// [`NetDriverOps::receive`].
     fn recycle_rx_buffer(&mut self, rx_buf: NetBufPtr) -> DevResult;
 
-    /// Poll the transmit queue and gives back the buffers for previous transmiting.
-    /// returns [`DevResult`].
+    /// Poll the transmit queue and gives back the buffers for previous
+    /// transmiting. returns [`DevResult`].
     fn recycle_tx_buffers(&mut self) -> DevResult;
 
     /// Transmits a packet in the buffer to the network, without blocking,

--- a/axdriver_net/src/lib.rs
+++ b/axdriver_net/src/lib.rs
@@ -3,20 +3,20 @@
 #![no_std]
 #![cfg_attr(doc, feature(doc_cfg))]
 
+extern crate alloc;
+
 #[cfg(feature = "fxmac")]
 /// fxmac driver for PhytiumPi
 pub mod fxmac;
 #[cfg(feature = "ixgbe")]
 /// ixgbe NIC device driver.
 pub mod ixgbe;
-mod net_buf;
-
-use core::ptr::NonNull;
 
 #[doc(no_inline)]
 pub use axdriver_base::{BaseDriverOps, DevError, DevResult, DeviceType};
 
-pub use self::net_buf::{NetBuf, NetBufBox, NetBufPool};
+mod net_buf;
+pub use self::net_buf::{NetBuf, NetBufBox, NetBufPool, NetBufPtr};
 
 /// The ethernet address of the NIC (MAC address).
 pub struct EthernetAddress(pub [u8; 6]);
@@ -65,44 +65,4 @@ pub trait NetDriverOps: BaseDriverOps {
     /// Allocate a memory buffer of a specified size for network transmission,
     /// returns [`DevResult`]
     fn alloc_tx_buffer(&mut self, size: usize) -> DevResult<NetBufPtr>;
-}
-
-/// A raw buffer struct for network device.
-pub struct NetBufPtr {
-    // The raw pointer of the original object.
-    raw_ptr: NonNull<u8>,
-    // The pointer to the net buffer.
-    buf_ptr: NonNull<u8>,
-    len: usize,
-}
-
-impl NetBufPtr {
-    /// Create a new [`NetBufPtr`].
-    pub fn new(raw_ptr: NonNull<u8>, buf_ptr: NonNull<u8>, len: usize) -> Self {
-        Self {
-            raw_ptr,
-            buf_ptr,
-            len,
-        }
-    }
-
-    /// Return raw pointer of the original object.
-    pub fn raw_ptr<T>(&self) -> *mut T {
-        self.raw_ptr.as_ptr() as *mut T
-    }
-
-    /// Return [`NetBufPtr`] buffer len.
-    pub fn packet_len(&self) -> usize {
-        self.len
-    }
-
-    /// Return [`NetBufPtr`] buffer as &[u8].
-    pub fn packet(&self) -> &[u8] {
-        unsafe { core::slice::from_raw_parts(self.buf_ptr.as_ptr() as *const u8, self.len) }
-    }
-
-    /// Return [`NetBufPtr`] buffer as &mut [u8].
-    pub fn packet_mut(&mut self) -> &mut [u8] {
-        unsafe { core::slice::from_raw_parts_mut(self.buf_ptr.as_ptr(), self.len) }
-    }
 }

--- a/axdriver_net/src/net_buf.rs
+++ b/axdriver_net/src/net_buf.rs
@@ -82,11 +82,11 @@ unsafe impl Sync for NetBuf {}
 
 impl NetBuf {
     const unsafe fn get_slice(&self, start: usize, len: usize) -> &[u8] {
-        core::slice::from_raw_parts(self.buf_ptr.as_ptr().add(start), len)
+        unsafe { core::slice::from_raw_parts(self.buf_ptr.as_ptr().add(start), len) }
     }
 
     const unsafe fn get_slice_mut(&mut self, start: usize, len: usize) -> &mut [u8] {
-        core::slice::from_raw_parts_mut(self.buf_ptr.as_ptr().add(start), len)
+        unsafe { core::slice::from_raw_parts_mut(self.buf_ptr.as_ptr().add(start), len) }
     }
 
     /// Returns the capacity of the buffer.
@@ -159,7 +159,7 @@ impl NetBuf {
     /// This function is unsafe because it may cause some memory issues,
     /// so we must ensure that it is called after calling `into_buf_ptr`.
     pub unsafe fn from_buf_ptr(ptr: NetBufPtr) -> Box<Self> {
-        Box::from_raw(ptr.raw_ptr::<Self>())
+        unsafe { Box::from_raw(ptr.raw_ptr::<Self>()) }
     }
 }
 

--- a/axdriver_net/src/net_buf.rs
+++ b/axdriver_net/src/net_buf.rs
@@ -1,9 +1,49 @@
-extern crate alloc;
-
-use crate::{DevError, DevResult, NetBufPtr};
 use alloc::{boxed::Box, sync::Arc, vec, vec::Vec};
 use core::ptr::NonNull;
+
 use spin::Mutex;
+
+use crate::{DevError, DevResult};
+
+/// A raw buffer struct for network device.
+pub struct NetBufPtr {
+    // The raw pointer of the original object.
+    raw_ptr: NonNull<u8>,
+    // The pointer to the net buffer.
+    buf_ptr: NonNull<u8>,
+    len: usize,
+}
+
+impl NetBufPtr {
+    /// Create a new [`NetBufPtr`].
+    pub fn new(raw_ptr: NonNull<u8>, buf_ptr: NonNull<u8>, len: usize) -> Self {
+        Self {
+            raw_ptr,
+            buf_ptr,
+            len,
+        }
+    }
+
+    /// Return raw pointer of the original object.
+    pub fn raw_ptr<T>(&self) -> *mut T {
+        self.raw_ptr.as_ptr() as *mut T
+    }
+
+    /// Return [`NetBufPtr`] buffer len.
+    pub fn packet_len(&self) -> usize {
+        self.len
+    }
+
+    /// Return [`NetBufPtr`] buffer as &[u8].
+    pub fn packet(&self) -> &[u8] {
+        unsafe { core::slice::from_raw_parts(self.buf_ptr.as_ptr() as *const u8, self.len) }
+    }
+
+    /// Return [`NetBufPtr`] buffer as &mut [u8].
+    pub fn packet_mut(&mut self) -> &mut [u8] {
+        unsafe { core::slice::from_raw_parts_mut(self.buf_ptr.as_ptr(), self.len) }
+    }
+}
 
 const MIN_BUFFER_LEN: usize = 1526;
 const MAX_BUFFER_LEN: usize = 65535;

--- a/axdriver_pci/Cargo.toml
+++ b/axdriver_pci/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axdriver_pci"
-edition = "2021"
+edition.workspace = true
 description = "Structures and functions for PCI bus operations"
 documentation = "https://arceos-org.github.io/axdriver_crates/axdriver_pci"
 keywords = ["arceos", "driver", "pci"]

--- a/axdriver_pci/src/lib.rs
+++ b/axdriver_pci/src/lib.rs
@@ -8,9 +8,9 @@
 
 #![no_std]
 
-pub use virtio_drivers::transport::pci::bus::{BarInfo, Cam, HeaderType, MemoryBarType, PciError};
 pub use virtio_drivers::transport::pci::bus::{
-    CapabilityInfo, Command, DeviceFunction, DeviceFunctionInfo, PciRoot, Status,
+    BarInfo, Cam, CapabilityInfo, Command, DeviceFunction, DeviceFunctionInfo, HeaderType,
+    MemoryBarType, PciError, PciRoot, Status,
 };
 
 /// Used to allocate MMIO regions for PCI BARs.

--- a/axdriver_virtio/Cargo.toml
+++ b/axdriver_virtio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axdriver_virtio"
-edition = "2021"
+edition.workspace = true
 description = "Wrappers of some devices in the `virtio-drivers` crate, that implement traits in the `axdriver_base` series crates"
 documentation = "https://arceos-org.github.io/axdriver_crates/axdriver_virtio"
 keywords = ["arceos", "driver", "vritio"]
@@ -12,13 +12,15 @@ repository.workspace = true
 categories.workspace = true
 
 [features]
+alloc = ["virtio-drivers/alloc"]
 block = ["axdriver_block"]
-net = ["axdriver_net"]
-gpu = ["axdriver_display"]
+gpu = ["alloc", "axdriver_display"]
+net = ["alloc", "axdriver_net"]
 
 [dependencies]
 axdriver_base = { workspace = true }
 axdriver_block = { workspace = true, optional = true }
+axdriver_display = { workspace = true, optional = true }
 axdriver_net = { workspace = true, optional = true }
-axdriver_display = { workspace = true, optional = true}
-virtio-drivers = "0.7.4"
+log = { workspace = true }
+virtio-drivers = { version = "0.7.4", default-features = false }

--- a/axdriver_virtio/src/blk.rs
+++ b/axdriver_virtio/src/blk.rs
@@ -1,6 +1,6 @@
 use axdriver_base::{BaseDriverOps, DevResult, DeviceType};
 use axdriver_block::BlockDriverOps;
-use virtio_drivers::{device::blk::VirtIOBlk as InnerDev, transport::Transport, Hal};
+use virtio_drivers::{Hal, device::blk::VirtIOBlk as InnerDev, transport::Transport};
 
 use crate::as_dev_err;
 

--- a/axdriver_virtio/src/blk.rs
+++ b/axdriver_virtio/src/blk.rs
@@ -1,7 +1,8 @@
-use crate::as_dev_err;
 use axdriver_base::{BaseDriverOps, DevResult, DeviceType};
 use axdriver_block::BlockDriverOps;
 use virtio_drivers::{device::blk::VirtIOBlk as InnerDev, transport::Transport, Hal};
+
+use crate::as_dev_err;
 
 /// The VirtIO block device driver.
 pub struct VirtIoBlkDev<H: Hal, T: Transport> {

--- a/axdriver_virtio/src/gpu.rs
+++ b/axdriver_virtio/src/gpu.rs
@@ -1,9 +1,8 @@
-extern crate alloc;
-use crate::as_dev_err;
-
 use axdriver_base::{BaseDriverOps, DevResult, DeviceType};
 use axdriver_display::{DisplayDriverOps, DisplayInfo, FrameBuffer};
 use virtio_drivers::{device::gpu::VirtIOGpu as InnerDev, transport::Transport, Hal};
+
+use crate::as_dev_err;
 
 /// The VirtIO GPU device driver.
 pub struct VirtIoGpuDev<H: Hal, T: Transport> {

--- a/axdriver_virtio/src/gpu.rs
+++ b/axdriver_virtio/src/gpu.rs
@@ -1,6 +1,6 @@
 use axdriver_base::{BaseDriverOps, DevResult, DeviceType};
 use axdriver_display::{DisplayDriverOps, DisplayInfo, FrameBuffer};
-use virtio_drivers::{device::gpu::VirtIOGpu as InnerDev, transport::Transport, Hal};
+use virtio_drivers::{Hal, device::gpu::VirtIOGpu as InnerDev, transport::Transport};
 
 use crate::as_dev_err;
 

--- a/axdriver_virtio/src/lib.rs
+++ b/axdriver_virtio/src/lib.rs
@@ -11,7 +11,7 @@
 //! [3]: https://docs.rs/virtio-drivers/latest/virtio_drivers/trait.Hal.html
 
 #![no_std]
-#![cfg_attr(doc, feature(doc_auto_cfg))]
+#![cfg_attr(doc, feature(doc_cfg))]
 
 #[cfg(feature = "block")]
 mod blk;

--- a/axdriver_virtio/src/lib.rs
+++ b/axdriver_virtio/src/lib.rs
@@ -18,16 +18,13 @@ extern crate alloc;
 
 #[cfg(feature = "block")]
 mod blk;
-#[cfg(feature = "block")]
-pub use self::blk::VirtIoBlkDev;
 
 #[cfg(feature = "gpu")]
 mod gpu;
-#[cfg(feature = "gpu")]
-pub use self::gpu::VirtIoGpuDev;
 
 #[cfg(feature = "net")]
 mod net;
+
 use axdriver_base::{DevError, DeviceType};
 use virtio_drivers::transport::DeviceType as VirtIoDevType;
 pub use virtio_drivers::{
@@ -39,6 +36,10 @@ pub use virtio_drivers::{
     },
 };
 
+#[cfg(feature = "block")]
+pub use self::blk::VirtIoBlkDev;
+#[cfg(feature = "gpu")]
+pub use self::gpu::VirtIoGpuDev;
 #[cfg(feature = "net")]
 pub use self::net::VirtIoNetDev;
 use self::pci::{DeviceFunction, DeviceFunctionInfo, PciRoot};

--- a/axdriver_virtio/src/lib.rs
+++ b/axdriver_virtio/src/lib.rs
@@ -28,16 +28,20 @@ pub use self::gpu::VirtIoGpuDev;
 
 #[cfg(feature = "net")]
 mod net;
-#[cfg(feature = "net")]
-pub use self::net::VirtIoNetDev;
-
-pub use virtio_drivers::transport::pci::bus as pci;
-pub use virtio_drivers::transport::{mmio::MmioTransport, pci::PciTransport, Transport};
-pub use virtio_drivers::{BufferDirection, Hal as VirtIoHal, PhysAddr};
-
-use self::pci::{DeviceFunction, DeviceFunctionInfo, PciRoot};
 use axdriver_base::{DevError, DeviceType};
 use virtio_drivers::transport::DeviceType as VirtIoDevType;
+pub use virtio_drivers::{
+    BufferDirection, Hal as VirtIoHal, PhysAddr,
+    transport::{
+        Transport,
+        mmio::MmioTransport,
+        pci::{PciTransport, bus as pci},
+    },
+};
+
+#[cfg(feature = "net")]
+pub use self::net::VirtIoNetDev;
+use self::pci::{DeviceFunction, DeviceFunctionInfo, PciRoot};
 
 /// Try to probe a VirtIO MMIO device from the given memory region.
 ///
@@ -48,6 +52,7 @@ pub fn probe_mmio_device(
     _reg_size: usize,
 ) -> Option<(DeviceType, MmioTransport)> {
     use core::ptr::NonNull;
+
     use virtio_drivers::transport::mmio::VirtIOHeader;
 
     let header = NonNull::new(reg_base as *mut VirtIOHeader).unwrap();

--- a/axdriver_virtio/src/lib.rs
+++ b/axdriver_virtio/src/lib.rs
@@ -13,17 +13,21 @@
 #![no_std]
 #![cfg_attr(doc, feature(doc_cfg))]
 
-#[cfg(feature = "block")]
-mod blk;
-#[cfg(feature = "gpu")]
-mod gpu;
-#[cfg(feature = "net")]
-mod net;
+#[cfg(feature = "alloc")]
+extern crate alloc;
 
 #[cfg(feature = "block")]
+mod blk;
+#[cfg(feature = "block")]
 pub use self::blk::VirtIoBlkDev;
+
+#[cfg(feature = "gpu")]
+mod gpu;
 #[cfg(feature = "gpu")]
 pub use self::gpu::VirtIoGpuDev;
+
+#[cfg(feature = "net")]
+mod net;
 #[cfg(feature = "net")]
 pub use self::net::VirtIoNetDev;
 

--- a/axdriver_virtio/src/net.rs
+++ b/axdriver_virtio/src/net.rs
@@ -1,10 +1,10 @@
-use crate::as_dev_err;
 use alloc::{sync::Arc, vec::Vec};
+
 use axdriver_base::{BaseDriverOps, DevError, DevResult, DeviceType};
 use axdriver_net::{EthernetAddress, NetBuf, NetBufBox, NetBufPool, NetBufPtr, NetDriverOps};
 use virtio_drivers::{device::net::VirtIONetRaw as InnerDev, transport::Transport, Hal};
 
-extern crate alloc;
+use crate::as_dev_err;
 
 const NET_BUF_LEN: usize = 1526;
 

--- a/axdriver_virtio/src/net.rs
+++ b/axdriver_virtio/src/net.rs
@@ -2,7 +2,7 @@ use alloc::{sync::Arc, vec::Vec};
 
 use axdriver_base::{BaseDriverOps, DevError, DevResult, DeviceType};
 use axdriver_net::{EthernetAddress, NetBuf, NetBufBox, NetBufPool, NetBufPtr, NetDriverOps};
-use virtio_drivers::{device::net::VirtIONetRaw as InnerDev, transport::Transport, Hal};
+use virtio_drivers::{Hal, device::net::VirtIONetRaw as InnerDev, transport::Transport};
 
 use crate::as_dev_err;
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,17 @@
+unstable_features = true
+
+style_edition = "2024"
+
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"
+
+normalize_comments = true
+wrap_comments = true
+
+condense_wildcard_suffixes = true
+enum_discrim_align_threshold = 20
+use_field_init_shorthand = true
+
+format_strings = true
+format_code_in_doc_comments = true
+format_macro_matchers = true


### PR DESCRIPTION
- introduce `rustfmt.toml` and format code
- update feature from `doc_auto_cfg` to `doc_cfg`
- remove CI `continue-on-error`
- some minor cleanup, no behavior change
- update to Rust edition 2024