### PR TITLE
feat(block): implement sdmmc

### DIFF
--- a/axdriver_block/Cargo.toml
+++ b/axdriver_block/Cargo.toml
@@ -21,4 +21,4 @@ sdmmc = ["dep:simple-sdmmc"]
 axdriver_base = { workspace = true }
 bcm2835-sdhci = { git = "https://github.com/lhw2002426/bcm2835-sdhci.git", rev = "e974f16", optional = true }
 log = { workspace = true }
-simple-sdmmc = { git = "https://github.com/Starry-OS/simple-sdmmc.git", rev = "9e6420c", optional = true }
+simple-sdmmc = { version = "0.1", optional = true }

--- a/axdriver_block/Cargo.toml
+++ b/axdriver_block/Cargo.toml
@@ -15,8 +15,10 @@ categories.workspace = true
 ramdisk = []
 bcm2835-sdhci = ["dep:bcm2835-sdhci"]
 default = []
+sdmmc = ["dep:simple-sdmmc"]
 
 [dependencies]
 axdriver_base = { workspace = true }
 bcm2835-sdhci = { git = "https://github.com/lhw2002426/bcm2835-sdhci.git", rev = "e974f16", optional = true }
 log = { workspace = true }
+simple-sdmmc = { git = "https://github.com/Starry-OS/simple-sdmmc.git", rev = "9e6420c", optional = true }

--- a/axdriver_block/src/lib.rs
+++ b/axdriver_block/src/lib.rs
@@ -9,6 +9,9 @@ pub mod ramdisk;
 #[cfg(feature = "bcm2835-sdhci")]
 pub mod bcm2835sdhci;
 
+#[cfg(feature = "sdmmc")]
+pub mod sdmmc;
+
 #[doc(no_inline)]
 pub use axdriver_base::{BaseDriverOps, DevError, DevResult, DeviceType};
 

--- a/axdriver_block/src/sdmmc.rs
+++ b/axdriver_block/src/sdmmc.rs
@@ -1,0 +1,74 @@
+//! SD/MMC driver based on SDIO.
+
+use axdriver_base::{BaseDriverOps, DevError, DevResult, DeviceType};
+use simple_sdmmc::SdMmc;
+
+use crate::BlockDriverOps;
+
+/// A SD/MMC driver.
+pub struct SdMmcDriver(SdMmc);
+
+impl SdMmcDriver {
+    /// Creates a new [`SdMmcDriver`] from the given base address.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `base` is a valid pointer to the SD/MMC
+    /// controller's register block and that no other code is concurrently
+    /// accessing the same hardware.
+    pub unsafe fn new(base: usize) -> Self {
+        Self(SdMmc::new(base))
+    }
+}
+
+impl BaseDriverOps for SdMmcDriver {
+    fn device_type(&self) -> DeviceType {
+        DeviceType::Block
+    }
+
+    fn device_name(&self) -> &str {
+        "sdmmc"
+    }
+}
+
+impl BlockDriverOps for SdMmcDriver {
+    fn num_blocks(&self) -> u64 {
+        self.0.num_blocks()
+    }
+
+    fn block_size(&self) -> usize {
+        SdMmc::BLOCK_SIZE
+    }
+
+    fn read_block(&mut self, block_id: u64, buf: &mut [u8]) -> DevResult {
+        let (blocks, remainder) = buf.as_chunks_mut::<{ SdMmc::BLOCK_SIZE }>();
+
+        if !remainder.is_empty() {
+            return Err(DevError::InvalidParam);
+        }
+
+        for (i, block) in blocks.iter_mut().enumerate() {
+            self.0.read_block(block_id as u32 + i as u32, block);
+        }
+
+        Ok(())
+    }
+
+    fn write_block(&mut self, block_id: u64, buf: &[u8]) -> DevResult {
+        let (blocks, remainder) = buf.as_chunks::<{ SdMmc::BLOCK_SIZE }>();
+
+        if !remainder.is_empty() {
+            return Err(DevError::InvalidParam);
+        }
+
+        for (i, block) in blocks.iter().enumerate() {
+            self.0.write_block(block_id as u32 + i as u32, block);
+        }
+
+        Ok(())
+    }
+
+    fn flush(&mut self) -> DevResult {
+        Ok(())
+    }
+}

--- a/axdriver_block/src/sdmmc.rs
+++ b/axdriver_block/src/sdmmc.rs
@@ -74,7 +74,7 @@ impl BlockDriverOps for SdMmcDriver {
         }
 
         for (i, block) in blocks.iter().enumerate() {
-            self.0.write_block(block_id as u32 + i as u32, block);
+            self.0.write_block(block_id + i as u32, block);
         }
 
         Ok(())

--- a/axdriver_block/src/sdmmc.rs
+++ b/axdriver_block/src/sdmmc.rs
@@ -17,7 +17,7 @@ impl SdMmcDriver {
     /// controller's register block and that no other code is concurrently
     /// accessing the same hardware.
     pub unsafe fn new(base: usize) -> Self {
-        Self(SdMmc::new(base))
+        Self(unsafe { SdMmc::new(base) })
     }
 }
 
@@ -49,7 +49,7 @@ impl BlockDriverOps for SdMmcDriver {
         }
 
         // check if block id exceeds device capacity
-        if block_id.saturating_add(blocks.len() as u64) > self.0.num_blocks(){
+        if block_id.saturating_add(blocks.len() as u64) > self.0.num_blocks() {
             return Err(DevError::InvalidParam);
         }
 
@@ -70,7 +70,7 @@ impl BlockDriverOps for SdMmcDriver {
         }
 
         // check if block id exceeds device capacity
-        if block_id.saturating_add(blocks.len() as u64) > self.0.num_blocks(){
+        if block_id.saturating_add(blocks.len() as u64) > self.0.num_blocks() {
             return Err(DevError::InvalidParam);
         }
 


### PR DESCRIPTION
- Implemented the `SdMmcDriver` in `axdriver_block/src/sdmmc.rs`, providing block device operations (read, write, flush) using the `simple-sdmmc` library.