### PR TITLE
feat(pci,virtio): read x86 legacy IRQ via PCI config space

### DIFF
--- a/axdriver_pci/src/lib.rs
+++ b/axdriver_pci/src/lib.rs
@@ -24,6 +24,8 @@ pub struct PciConfigAccess {
     cam: Cam,
 }
 
+// SAFETY: PciConfigAccess is used like PciRoot: the raw pointer points to a
+// static MMIO mapping that is valid for the lifetime of the program.
 unsafe impl Send for PciConfigAccess {}
 unsafe impl Sync for PciConfigAccess {}
 
@@ -60,13 +62,20 @@ impl PciConfigAccess {
     /// Reads a 32-bit word from PCI configuration space.
     pub fn read_word(&self, device_function: DeviceFunction, register_offset: u8) -> u32 {
         let address = self.cam_offset(device_function, register_offset);
+        // SAFETY: The pointer arithmetic stays within the MMIO window because
+        // cam_offset() produces offsets bounded by Cam::size().
         unsafe { self.mmio_base.add((address >> 2) as usize).read_volatile() }
     }
 
     /// Writes a 32-bit word to PCI configuration space.
     pub fn write_word(&mut self, device_function: DeviceFunction, register_offset: u8, data: u32) {
         let address = self.cam_offset(device_function, register_offset);
-        unsafe { self.mmio_base.add((address >> 2) as usize).write_volatile(data) }
+        // SAFETY: Same as read_word.
+        unsafe {
+            self.mmio_base
+                .add((address >> 2) as usize)
+                .write_volatile(data)
+        }
     }
 }
 

--- a/axdriver_pci/src/lib.rs
+++ b/axdriver_pci/src/lib.rs
@@ -13,6 +13,63 @@ pub use virtio_drivers::transport::pci::bus::{
     MemoryBarType, PciError, PciRoot, Status,
 };
 
+/// Provides read/write access to PCI configuration space registers.
+///
+/// The `virtio-drivers` crate exposes `PciRoot` but keeps its internal
+/// config-space access helpers private. This type re-implements the same MMIO
+/// access so callers can read arbitrary PCI config registers such as
+/// `Interrupt Line`.
+pub struct PciConfigAccess {
+    mmio_base: *mut u32,
+    cam: Cam,
+}
+
+unsafe impl Send for PciConfigAccess {}
+unsafe impl Sync for PciConfigAccess {}
+
+impl PciConfigAccess {
+    /// Creates a new PCI config-space accessor from the ECAM/MMIO base address.
+    ///
+    /// # Safety
+    ///
+    /// `mmio_base` must point to a valid mapped PCI configuration window.
+    pub unsafe fn new(mmio_base: *mut u8, cam: Cam) -> Self {
+        assert!(mmio_base as usize & 0x3 == 0);
+        Self {
+            mmio_base: mmio_base as *mut u32,
+            cam,
+        }
+    }
+
+    fn cam_offset(&self, device_function: DeviceFunction, register_offset: u8) -> u32 {
+        assert!(device_function.valid());
+
+        let bdf = (device_function.bus as u32) << 8
+            | (device_function.device as u32) << 3
+            | device_function.function as u32;
+        let address =
+            bdf << match self.cam {
+                Cam::MmioCam => 8,
+                Cam::Ecam => 12,
+            } | (register_offset as u32 & !0x3);
+        assert!(address < self.cam.size());
+        assert!(address & 0x3 == 0);
+        address
+    }
+
+    /// Reads a 32-bit word from PCI configuration space.
+    pub fn read_word(&self, device_function: DeviceFunction, register_offset: u8) -> u32 {
+        let address = self.cam_offset(device_function, register_offset);
+        unsafe { self.mmio_base.add((address >> 2) as usize).read_volatile() }
+    }
+
+    /// Writes a 32-bit word to PCI configuration space.
+    pub fn write_word(&mut self, device_function: DeviceFunction, register_offset: u8, data: u32) {
+        let address = self.cam_offset(device_function, register_offset);
+        unsafe { self.mmio_base.add((address >> 2) as usize).write_volatile(data) }
+    }
+}
+
 /// Used to allocate MMIO regions for PCI BARs.
 pub struct PciRangeAllocator {
     _start: u64,

--- a/axdriver_virtio/Cargo.toml
+++ b/axdriver_virtio/Cargo.toml
@@ -22,5 +22,6 @@ axdriver_base = { workspace = true }
 axdriver_block = { workspace = true, optional = true }
 axdriver_display = { workspace = true, optional = true }
 axdriver_net = { workspace = true, optional = true }
+axdriver_pci = { workspace = true }
 log = { workspace = true }
 virtio-drivers = { version = "0.7.5", default-features = false }

--- a/axdriver_virtio/src/lib.rs
+++ b/axdriver_virtio/src/lib.rs
@@ -26,6 +26,7 @@ mod gpu;
 mod net;
 
 use axdriver_base::{DevError, DeviceType};
+use axdriver_pci::PciConfigAccess;
 use virtio_drivers::transport::DeviceType as VirtIoDevType;
 pub use virtio_drivers::{
     BufferDirection, Hal as VirtIoHal, PhysAddr,
@@ -70,12 +71,37 @@ pub fn probe_pci_device<H: VirtIoHal>(
     root: &mut PciRoot,
     bdf: DeviceFunction,
     dev_info: &DeviceFunctionInfo,
-) -> Option<(DeviceType, PciTransport)> {
+    config: &PciConfigAccess,
+) -> Option<(DeviceType, PciTransport, usize)> {
     use virtio_drivers::transport::pci::virtio_device_type;
 
     let dev_type = virtio_device_type(dev_info).and_then(as_dev_type)?;
     let transport = PciTransport::new::<H>(root, bdf).ok()?;
-    Some((dev_type, transport))
+    #[cfg(target_arch = "x86_64")]
+    let irq = legacy_irq_for_bdf(config, bdf);
+    #[cfg(target_arch = "riscv64")]
+    let irq = 0x20 + (bdf.device & 3) as usize;
+    #[cfg(target_arch = "loongarch64")]
+    let irq = 0x10 + (bdf.device & 3) as usize;
+    #[cfg(target_arch = "aarch64")]
+    let irq = 0x23 + (bdf.device & 3) as usize;
+
+    #[cfg(target_arch = "x86_64")]
+    if irq == 0 || irq == 0xff {
+        log::warn!(
+            "PCI device {:?}: Interrupt Line not assigned ({:#x})",
+            bdf,
+            irq
+        );
+        return None;
+    }
+
+    Some((dev_type, transport, irq))
+}
+
+#[cfg(target_arch = "x86_64")]
+fn legacy_irq_for_bdf(config: &PciConfigAccess, bdf: DeviceFunction) -> usize {
+    (config.read_word(bdf, 0x3c) & 0xff) as usize
 }
 
 const fn as_dev_type(t: VirtIoDevType) -> Option<DeviceType> {


### PR DESCRIPTION
## Related Issue

https://github.com/Starry-OS/StarryOS/issues/129

On x86_64, a host-side TCP client could not complete a TCP echo exchange with a server running inside the system. The server never reported an accepted connection, the client blocked indefinitely, and the server could not be terminated with `Ctrl+C`. See the issue for full reproduction steps.


## Description

This PR fixes x86 legacy IRQ discovery for VirtIO PCI devices.

Previously, the x86 path relied on derived or hardcoded IRQ assumptions, which do not reliably match the actual platform-assigned legacy INTx routing. On x86, the correct legacy IRQ should be taken from the PCI configuration space `Interrupt Line` register instead.

To support this, this PR adds a small PCI config-space accessor in `axdriver_pci` and uses it in `axdriver_virtio` to fetch the IRQ from PCI config space during device probing.

## Implementation

This PR includes two changes:

- Add `PciConfigAccess` to `axdriver_pci`
  - This provides read/write access to arbitrary PCI configuration space registers through the existing ECAM/MMIO mapping.
  - It is intended as a minimal helper for drivers that need config-space fields not exposed by `virtio-drivers`.

- Update `axdriver_virtio::probe_pci_device()` on x86
  - Accept a `PciConfigAccess` reference.
  - Read the legacy IRQ from PCI config offset `0x3C` (`Interrupt Line`).
  - Reject invalid/unassigned values (`0` and `0xff`) on x86 instead of treating them as usable IRQs.

## Additional Context

This change is based on the same fix direction used in `x-kernel` commit, where x86 VirtIO probing was changed to use the PCI `Interrupt Line` register instead of hardcoded IRQ derivation.

I kept this PR intentionally small so it can be reviewed independently from any follow-up work around MSI-X or higher-level interrupt handling.