### PR TITLE
feat: upgrade virtio-drivers to 0.12.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ axdriver_pci = { path = "axdriver_pci", version = "0.1" }
 axdriver_virtio = { path = "axdriver_virtio", version = "0.1" }
 axdriver_vsock = { path = "axdriver_vsock", version = "0.1" }
 log = "0.4"
+virtio-drivers = { version = "0.12.0", default-features = false }
 
 # For local dev and dry-run: use local crates until published to crates.io
 [patch.crates-io]

--- a/axdriver_pci/Cargo.toml
+++ b/axdriver_pci/Cargo.toml
@@ -13,4 +13,4 @@ categories.workspace = true
 readme = "README.md"
 
 [dependencies]
-virtio-drivers = "0.12.0"
+virtio-drivers = { workspace = true }

--- a/axdriver_pci/Cargo.toml
+++ b/axdriver_pci/Cargo.toml
@@ -13,4 +13,4 @@ categories.workspace = true
 readme = "README.md"
 
 [dependencies]
-virtio-drivers = "0.7.4"
+virtio-drivers = "0.12.0"

--- a/axdriver_pci/src/lib.rs
+++ b/axdriver_pci/src/lib.rs
@@ -9,10 +9,8 @@
 #![no_std]
 
 pub use virtio_drivers::transport::pci::bus::{
-    BarInfo, Cam, ConfigurationAccess, HeaderType, MemoryBarType, MmioCam, PciError,
-};
-pub use virtio_drivers::transport::pci::bus::{
-    CapabilityInfo, Command, DeviceFunction, DeviceFunctionInfo, PciRoot, Status,
+    BarInfo, Cam, CapabilityInfo, Command, ConfigurationAccess, DeviceFunction, DeviceFunctionInfo,
+    HeaderType, MemoryBarType, MmioCam, PciError, PciRoot, Status,
 };
 
 /// Used to allocate MMIO regions for PCI BARs.

--- a/axdriver_pci/src/lib.rs
+++ b/axdriver_pci/src/lib.rs
@@ -8,7 +8,9 @@
 
 #![no_std]
 
-pub use virtio_drivers::transport::pci::bus::{BarInfo, Cam, HeaderType, MemoryBarType, PciError};
+pub use virtio_drivers::transport::pci::bus::{
+    BarInfo, Cam, ConfigurationAccess, HeaderType, MemoryBarType, MmioCam, PciError,
+};
 pub use virtio_drivers::transport::pci::bus::{
     CapabilityInfo, Command, DeviceFunction, DeviceFunctionInfo, PciRoot, Status,
 };

--- a/axdriver_virtio/Cargo.toml
+++ b/axdriver_virtio/Cargo.toml
@@ -28,4 +28,4 @@ axdriver_input = { version = "0.1.4-preview.3", optional = true }
 axdriver_net = { version = "0.1.4-preview.3", optional = true }
 axdriver_vsock = { version = "0.1.4-preview.3", optional = true }
 log = { workspace = true }
-virtio-drivers = { version = "0.12.0", default-features = false }
+virtio-drivers = { workspace = true }

--- a/axdriver_virtio/Cargo.toml
+++ b/axdriver_virtio/Cargo.toml
@@ -28,4 +28,4 @@ axdriver_input = { version = "0.1.4-preview.3", optional = true }
 axdriver_net = { version = "0.1.4-preview.3", optional = true }
 axdriver_vsock = { version = "0.1.4-preview.3", optional = true }
 log = { workspace = true }
-virtio-drivers = { version = "0.7.4", default-features = false }
+virtio-drivers = { version = "0.12.0", default-features = false }

--- a/axdriver_virtio/src/input.rs
+++ b/axdriver_virtio/src/input.rs
@@ -70,7 +70,8 @@ impl<H: Hal, T: Transport> InputDriverOps for VirtIoInputDev<H, T> {
     fn get_event_bits(&mut self, ty: EventType, out: &mut [u8]) -> DevResult<bool> {
         let read = self
             .inner
-            .query_config_select(InputConfigSelect::EvBits, ty as u8, out);
+            .query_config_select(InputConfigSelect::EvBits, ty as u8, out)
+            .map_err(as_dev_err)?;
         Ok(read != 0)
     }
 

--- a/axdriver_virtio/src/lib.rs
+++ b/axdriver_virtio/src/lib.rs
@@ -60,7 +60,7 @@ pub fn probe_mmio_device(
     use core::ptr::NonNull;
     use virtio_drivers::transport::mmio::VirtIOHeader;
 
-    let header = NonNull::new(reg_base as *mut VirtIOHeader).unwrap();
+    let header = NonNull::new(reg_base as *mut VirtIOHeader)?;
     let transport = unsafe { MmioTransport::new(header, reg_size) }.ok()?;
     let dev_type = as_dev_type(transport.device_type())?;
     Some((dev_type, transport))
@@ -126,9 +126,7 @@ const fn as_dev_err(e: virtio_drivers::Error) -> DevError {
             OutputBufferTooShort(_) | BufferTooShort | BufferTooLong(_, _) => {
                 DevError::InvalidParam
             }
-            UnexpectedDataInPacket | PeerSocketShutdown => {
-                DevError::Io
-            }
+            UnexpectedDataInPacket | PeerSocketShutdown => DevError::Io,
             InsufficientBufferSpaceInPeer => DevError::Again,
             RecycledWrongBuffer => DevError::BadState,
         },

--- a/axdriver_virtio/src/lib.rs
+++ b/axdriver_virtio/src/lib.rs
@@ -45,7 +45,7 @@ pub use virtio_drivers::transport::pci::bus as pci;
 pub use virtio_drivers::transport::{mmio::MmioTransport, pci::PciTransport, Transport};
 pub use virtio_drivers::{BufferDirection, Hal as VirtIoHal, PhysAddr};
 
-use self::pci::{DeviceFunction, DeviceFunctionInfo, PciRoot};
+use self::pci::{ConfigurationAccess, DeviceFunction, DeviceFunctionInfo, PciRoot};
 use axdriver_base::{DevError, DeviceType};
 use virtio_drivers::transport::DeviceType as VirtIoDevType;
 
@@ -55,13 +55,13 @@ use virtio_drivers::transport::DeviceType as VirtIoDevType;
 /// for later operations. Otherwise, returns [`None`].
 pub fn probe_mmio_device(
     reg_base: *mut u8,
-    _reg_size: usize,
-) -> Option<(DeviceType, MmioTransport)> {
+    reg_size: usize,
+) -> Option<(DeviceType, MmioTransport<'static>)> {
     use core::ptr::NonNull;
     use virtio_drivers::transport::mmio::VirtIOHeader;
 
     let header = NonNull::new(reg_base as *mut VirtIOHeader).unwrap();
-    let transport = unsafe { MmioTransport::new(header) }.ok()?;
+    let transport = unsafe { MmioTransport::new(header, reg_size) }.ok()?;
     let dev_type = as_dev_type(transport.device_type())?;
     Some((dev_type, transport))
 }
@@ -70,8 +70,8 @@ pub fn probe_mmio_device(
 ///
 /// If the device is recognized, returns the device type and a transport object
 /// for later operations. Otherwise, returns [`None`].
-pub fn probe_pci_device<H: VirtIoHal>(
-    root: &mut PciRoot,
+pub fn probe_pci_device<H: VirtIoHal, C: ConfigurationAccess>(
+    root: &mut PciRoot<C>,
     bdf: DeviceFunction,
     dev_info: &DeviceFunctionInfo,
 ) -> Option<(DeviceType, PciTransport, usize)> {
@@ -87,7 +87,7 @@ pub fn probe_pci_device<H: VirtIoHal>(
     const PCI_IRQ_BASE: usize = 0x23;
 
     let dev_type = virtio_device_type(dev_info).and_then(as_dev_type)?;
-    let transport = PciTransport::new::<H>(root, bdf).ok()?;
+    let transport = PciTransport::new::<H, C>(root, bdf).ok()?;
     let irq = PCI_IRQ_BASE + (bdf.device & 3) as usize;
     Some((dev_type, transport, irq))
 }
@@ -126,7 +126,7 @@ const fn as_dev_err(e: virtio_drivers::Error) -> DevError {
             OutputBufferTooShort(_) | BufferTooShort | BufferTooLong(_, _) => {
                 DevError::InvalidParam
             }
-            UnexpectedDataInPacket | PeerSocketShutdown | NoResponseReceived | ConnectionFailed => {
+            UnexpectedDataInPacket | PeerSocketShutdown => {
                 DevError::Io
             }
             InsufficientBufferSpaceInPeer => DevError::Again,


### PR DESCRIPTION
## Description
https://github.com/arceos-org/axdriver_crates/issues/17
This PR updates `axdriver` to work with the `virtio-drivers 0.12.0` upgrade.

## Implementation

- Adapt PCI probing to the new generic `PciRoot<C>` interface
- Create `PciRoot` from `MmioCam` instead of raw ECAM pointer + `Cam`
- Update VirtIO probing to use the new `probe_pci_device::<H, C>(...)` form
- Adjust MMIO transport and `PhysAddr`-related type usage to match the new APIs
- Update `Cargo.lock`

## Additional Context

This PR is a follow-up to the corresponding `axdriver_crates` PR that upgrades `virtio-drivers` to `0.12.0`.