### PR TITLE
Downgrade virtio-drivers version to 0.7.4

### DIFF
--- a/axdriver_virtio/Cargo.toml
+++ b/axdriver_virtio/Cargo.toml
@@ -23,4 +23,4 @@ axdriver_block = { workspace = true, optional = true }
 axdriver_display = { workspace = true, optional = true }
 axdriver_net = { workspace = true, optional = true }
 log = { workspace = true }
-virtio-drivers = { version = "0.7.5", default-features = false }
+virtio-drivers = { version = "0.7.4", default-features = false }


### PR DESCRIPTION
```text
error: failed to select a version for `virtio-drivers`.
    ... required by package `axdriver_virtio v0.1.3 (https://github.com/arceos-org/axdriver_crates.git?tag=v0.1.3#aa4e9efc)`
    ... which satisfies git dependency `axdriver_virtio` of package `axdriver v0.2.0 (/Users/debin/Desktop/Codes/arceos/arceos_arm/modules/axdriver)`
    ... which satisfies path dependency `axdriver` (locked to 0.2.0) of package `axfeat v0.2.0 (/Users/debin/Desktop/Codes/arceos/arceos_arm/api/axfeat)`
    ... which satisfies path dependency `axfeat` (locked to 0.2.0) of package `axlibc v0.2.0 (/Users/debin/Desktop/Codes/arceos/arceos_arm/ulib/axlibc)`
versions that meet the requirements `^0.7.5` are: 0.7.5

all possible versions conflict with previously selected packages.

  previously selected package `virtio-drivers v0.7.4`
    ... which satisfies dependency `virtio-drivers = "^0.7.4"` (locked to 0.7.4) of package `axdriver_pci v0.1.3 (https://github.com/arceos-org/axdriver_crates.git?tag=v0.1.3#aa4e9efc)`
    ... which satisfies git dependency `axdriver_pci` of package `axdriver v0.2.0 (/Users/debin/Desktop/Codes/arceos/arceos_arm/modules/axdriver)`
    ... which satisfies path dependency `axdriver` (locked to 0.2.0) of package `axfeat v0.2.0 (/Users/debin/Desktop/Codes/arceos/arceos_arm/api/axfeat)`
    ... which satisfies path dependency `axfeat` (locked to 0.2.0) of package `axlibc v0.2.0 (/Users/debin/Desktop/Codes/arceos/arceos_arm/ulib/axlibc)`

failed to select a version for `virtio-drivers` which could resolve this conflict
error: `cargo metadata` exited with an error: 
scripts/make/platform.mk:39: *** PLAT_CONFIG= is not a valid platform configuration file.  Stop.
```